### PR TITLE
fix typo in command-line help

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ struct Opt {
 
     #[structopt(
         long = "--color",
-        help = "Wether to enable colorful output. Choose between 'always', 'auto', or 'never'. Default is 'auto'"
+        help = "Whether to enable colorful output. Choose between 'always', 'auto', or 'never'. Default is 'auto'"
     )]
     color_when: Option<ColorWhen>,
 }


### PR DESCRIPTION
Hi! I've been using `ruplacer` for a bit now, and it's excellent. I noticed a small typo in the command line help, so I figured I'd just make a PR to fix it. Feel free to fix it manually and close this if that's easier.